### PR TITLE
Added tarmac retrying and fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ For users that don't want to copy paste a security cookie each time they can sim
 
 ## Limitations
 
-The most blarring limitation of this tool is that it does not work with layers that are not fully rasterized. This means any layers with effects such drop shadows or masks will have those effects ignored unless they are manually rasterized/merged into the layer. It's a bit annoying, but I think it's not an unreasonable limitation to work within.
+The most blaring limitation of this tool is that it does not work with layers that are not fully rasterized. This means any layers with effects such drop shadows or masks will have those effects ignored unless they are manually rasterized/merged into the layer. It's a bit annoying, but I think it's not an unreasonable limitation to work within.
 
 ## Work to be done
 
-Most image editting programs can export files to a `.psd` format; this is the reason I chose to make the tool work with `.psd` files. However, most of these programs do not match Adobe's format exactly.
+Most image editing programs can export files to a `.psd` format; this is the reason I chose to make the tool work with `.psd` files. However, most of these programs do not match Adobe's format exactly.
 
 One of the best examples of this are text objects. For example, say you created a text layer in GIMP and exported the project to a `.psd` file. In the conversion process GIMP would rasterize that text layer and it would lose any meaningful data about the text (e.g. the content, color, size, etc). This is a problem though because GIMP users using this tool still want `psd_ui` to recognize that text layer as a text object when they import their UI into studio.
 

--- a/psd_ui/upload.py
+++ b/psd_ui/upload.py
@@ -15,7 +15,7 @@ def VerifyUsername(cookie):
 		response = requests.get("https://www.roblox.com/game/GetCurrentUser.ashx", cookies={".ROBLOSECURITY": cookie})
 		response = requests.get("https://api.roblox.com/users/" + response.text)
 		username = response.json().get("Username")
-		valid = input("The username assosiated with this cookie is " + username + ". Is this correct? (y/n) : ")
+		valid = input("The username associated with this cookie is " + username + ". Is this correct? (y/n) : ")
 		return valid == "y"
 	except:
 		print("Something was wrong with the cookie provided. Ensure it's a valid account cookie.")
@@ -32,6 +32,8 @@ def TarmacSync(outputPath, cookie):
 	subprocess.run([
 		"tarmac", "sync", 
 		"--target", "roblox",
+		"--retry", "10",
+		"--retry-delay", "60",
 		"--auth", cookie
 	], cwd = parentPath.as_posix())
 


### PR DESCRIPTION
Very frustrating with tarmac constantly being rate limited causing errors and failing. This will make sure that tarmac constantly retries after the rate limit has been reset (approximately one minute). The retry amount really doesn't matter since tarmac resets it after a minute, so just extra precautionary measures.